### PR TITLE
[fix] (my-site): preload errors

### DIFF
--- a/.semaphore/my-site-build.yml
+++ b/.semaphore/my-site-build.yml
@@ -9,6 +9,8 @@ blocks:
     skip:
       when: branch != 'master' AND branch != 'develop'
     task:
+      secrets:
+        - name: production-env
       jobs:
         - name: Build Core
           commands:

--- a/.semaphore/my-site-deploy-stage.yml
+++ b/.semaphore/my-site-deploy-stage.yml
@@ -5,6 +5,7 @@ blocks:
     task:
       secrets:
         - name: netlify-auth-svelte-monorepo
+        - name: production-env
       jobs:
         - name: Deploy Website
           commands:

--- a/apps/my-site/package.json
+++ b/apps/my-site/package.json
@@ -68,7 +68,7 @@
     "rollup-plugin-babel": "^4.0.2",
     "rollup-plugin-svelte": "^5.1.0",
     "rollup-plugin-terser": "^5.2.0",
-    "sapper": "^0.27.0",
+    "sapper": "^0.27.9",
     "svelte": "^3.18.2",
     "svelte-jester": "^1.0.3",
     "to-vfile": "^6.0.0",

--- a/apps/my-site/rollup.config.js
+++ b/apps/my-site/rollup.config.js
@@ -1,7 +1,7 @@
 import dotenv from 'dotenv'
 dotenv.config()
 
-import alias from '@rollup/plugin-alias'
+// import alias from '@rollup/plugin-alias'
 import resolve from '@rollup/plugin-node-resolve'
 import replace from '@rollup/plugin-replace'
 import commonjs from '@rollup/plugin-commonjs'
@@ -12,7 +12,7 @@ import { terser } from 'rollup-plugin-terser'
 import config from 'sapper/config/rollup.js'
 import remark from 'remark'
 import html from 'remark-html'
-import { join } from 'path'
+// import { join } from 'path'
 
 import pkg from './package.json'
 
@@ -37,21 +37,13 @@ const markdown = () => ({
   },
 })
 
-const extensions = ['.js']
+// const extensions = ['.js']
 
 export default {
   client: {
     input: config.client.input(),
     output: config.client.output(),
     plugins: [
-      alias({
-        entries: [
-          {
-            find: '@sapper/app',
-            replacement: join(__dirname, 'src/node_modules/@sapper/app'),
-          },
-        ],
-      }),
       replace({
         'process.browser': true,
         'process.env.NODE_ENV': JSON.stringify(mode),
@@ -68,8 +60,18 @@ export default {
       resolve({
         browser: true,
         dedupe: ['svelte'],
-        extensions,
+        // extensions,
       }),
+      /*
+      alias({
+        entries: [
+          {
+            find: '@sapper/app',
+            replacement: join(__dirname, 'src/node_modules/@sapper/app'),
+          },
+        ],
+      }),
+      */
       commonjs(),
       json({
         compact: true,
@@ -103,7 +105,7 @@ export default {
           module: true,
         }),
     ],
-
+    // context: "window",
     onwarn,
   },
 
@@ -111,7 +113,6 @@ export default {
     input: config.server.input(),
     output: config.server.output(),
     plugins: [
-      resolve({ preferBuiltins: true }),
       replace({
         'process.browser': false,
         'process.env.NODE_ENV': JSON.stringify(mode),
@@ -135,7 +136,6 @@ export default {
       require('module').builtinModules ||
         Object.keys(process.binding('natives')),
     ),
-
     onwarn,
   },
 
@@ -155,7 +155,6 @@ export default {
       commonjs(),
       !dev && terser(),
     ],
-
     onwarn,
   },
 }

--- a/apps/my-site/src/client.js
+++ b/apps/my-site/src/client.js
@@ -1,4 +1,4 @@
-import * as sapper from '@sapper/app'
+import * as sapper from './node_modules/@sapper/app'
 
 sapper.start({
   target: document.querySelector('#sapper'),

--- a/apps/my-site/src/components/Nav.svelte
+++ b/apps/my-site/src/components/Nav.svelte
@@ -60,7 +60,7 @@
     <!-- for the blog link, we're using rel=prefetch so that Sapper prefetches
 		     the blog data when we hover over the link or tap it on a touchscreen -->
     <li>
-      <a rel="prefetch" class:selected={segment === 'blog'} href="blog">blog</a>
+      <a class:selected={segment === 'blog'} href="blog">blog</a>
     </li>
   </ul>
 </nav>

--- a/apps/my-site/src/routes/blog/[slug].svelte
+++ b/apps/my-site/src/routes/blog/[slug].svelte
@@ -1,14 +1,16 @@
 <script context="module">
-  import axios from 'axios'
-
   const siteUrl = process.env.SITE_URL
   const postUrl = `${siteUrl}/blog`
 
-  export const preload = ({ params }) =>
-    axios
-      .get(`${postUrl}/${params.slug}.json`)
-      .then(posts => ({ post: posts.data }))
+  export const preload = async function({ params }) {
+    const fetchBlog = await this.fetch(`/blog/${params.slug}.json`)
+      .then(response => response.json())
+      .then(data => {
+        return { post: data }
+      })
       .catch(console.error)
+    return fetchBlog
+  }
 </script>
 
 <script>

--- a/apps/my-site/src/routes/blog/index.svelte
+++ b/apps/my-site/src/routes/blog/index.svelte
@@ -1,14 +1,14 @@
 <script context="module">
-  import axios from 'axios'
-
   const siteUrl = process.env.SITE_URL
-  const blogUrl = `${siteUrl}/blog.json`
-
-  export const preload = () =>
-    axios
-      .get(blogUrl)
-      .then(posts => ({ posts: posts.data }))
+  const blogUrl = `blog.json`
+  export const preload = async function() {
+    return await this.fetch(blogUrl)
+      .then(response => response.json())
+      .then(data => {
+        return { posts: data }
+      })
       .catch(console.error)
+  }
 </script>
 
 <script>

--- a/yarn.lock
+++ b/yarn.lock
@@ -12486,7 +12486,7 @@ sane@^4.0.3:
     minimist "^1.1.1"
     walker "~1.0.5"
 
-sapper@^0.27.0:
+sapper@^0.27.9:
   version "0.27.9"
   resolved "https://registry.yarnpkg.com/sapper/-/sapper-0.27.9.tgz#c3ec00b44dd35d25e89d2d697c9bb1d27409dbe4"
   integrity sha512-v3b3UgGeVhFUOpA5IZgdThdr4nZ6aMH6IxDsg1Yu2UWHWEV9vW/Zehch9M/xqJNp/x9n9X+S9syJg1s5QOOmFA==


### PR DESCRIPTION
- transpiling of fat-arrow functions return `this` errors when compiled by rollup. 
- Use absolute paths (site-centric) for importing blog data  